### PR TITLE
Add dbplyr snippets

### DIFF
--- a/preparation_note_blog.qmd
+++ b/preparation_note_blog.qmd
@@ -188,6 +188,9 @@ données avec <code>DuckDB</code>
 
 {{< include snippets/1_create_db_r.qmd >}}
 
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/1_create_db_r_dbplyr.qmd >}}
 :::
 
 Pour rapidement avoir une idée des informations présentes dans ces données,
@@ -208,6 +211,10 @@ le code ci-dessous peut être utilisé :
 ## `R` {.unnumbered .unlisted} 
 
 {{< include snippets/2_select_schema_r.qmd >}}
+
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/2_select_schema_r_dbplyr.qmd >}}
 
 :::
 
@@ -244,11 +251,15 @@ extraire toutes les modalités des variables dont la description contient le ter
 
 {{< include snippets/3_select_documentation_r.qmd >}}
 
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/3_select_documentation_r_dbplyr.qmd >}}
+
 :::
 
 ```{ojs}
 //| echo: false
-query = "SELECT * FROM documentation_indiv WHERE CONTAINS(description_variable, 'Catégorie')"
+query = "SELECT * FROM documentation_logement WHERE CONTAINS(description_variable, 'Catégorie')"
 Inputs.table(
     db.query(query)
 )
@@ -273,6 +284,10 @@ Il est possible d'avoir du détail sur celles-ci avec la requête suivante :
 ## `R` {.unnumbered .unlisted} 
 
 {{< include snippets/4_selectz_r.qmd >}}
+
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/4_selectz_r_dbplyr.qmd >}}
 
 :::
 
@@ -317,6 +332,10 @@ Pour les premières lignes, la commande à utiliser est `LIMIT`.
 
 {{< include snippets/5_limit_r.qmd >}}
 
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/5_limit_r_dbplyr.qmd >}}
+
 :::
 
 ```{ojs}
@@ -351,6 +370,10 @@ Inputs.table(
 
 {{< include snippets/5_sample_r.qmd >}}
 
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/5_sample_r_dbplyr.qmd >}}
+
 :::
 
 ```{ojs}
@@ -382,6 +405,10 @@ Celles-ci peuvent être renommées en appliquant au passage la clause `AS`.
 
 {{< include snippets/6_sample_columns_r.qmd >}}
 
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/6_sample_columns_r_dbplyr.qmd >}}
+
 :::
 
 ```{ojs}
@@ -409,6 +436,10 @@ De nombreux exemples peuvent être trouvés sur [cette page](https://duckdb.org/
 ## `R` {.unnumbered .unlisted} 
 
 {{< include snippets/7_use_regex_r.qmd >}}
+
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/7_use_regex_r_dbplyr.qmd >}}
 
 :::
 
@@ -442,6 +473,11 @@ de la Haute-Garonne (31) et de l'Hérault (34).
 
 {{< include snippets/8_filter_dpts_r.qmd >}}
 
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/8_filter_dpts_r_dbplyr.qmd >}}
+
+
 :::
 
 
@@ -471,6 +507,10 @@ Pour cela, le code suivant peut servir de modèle :
 ## `R` {.unnumbered .unlisted} 
 
 {{< include snippets/8_filter_regions_r.qmd >}}
+
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/8_filter_regions_r_dbplyr.qmd >}}
 
 :::
 
@@ -508,6 +548,10 @@ la requête suivante peut être utilisée :
 ## `R` {.unnumbered .unlisted} 
 
 {{< include snippets/8_filter_dates_r.qmd >}}
+
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/8_filter_dates_r_dbplyr.qmd >}}
 
 :::
 
@@ -559,6 +603,11 @@ présents dans la base de données.
 
 {{< include snippets/9_distinct_arrondissements_r.qmd >}}
 
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/9_distinct_arrondissements_r_dbplyr.qmd >}}
+
+
 :::
 
 ```{ojs}
@@ -588,6 +637,10 @@ le nombre d'habitants de Toulouse qui ont changé de logement en un an:
 ## `R` {.unnumbered .unlisted} 
 
 {{< include snippets/10_use_cast_r.qmd >}}
+
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/10_use_cast_r_dbplyr.qmd >}}
 
 :::
 
@@ -638,6 +691,10 @@ dont la syntaxe reproduit celle du _package_ `R` `ggplot2`, plutôt que sur
 ## `R` {.unnumbered .unlisted} 
 
 {{< include snippets/11_pyramide_ages_r.qmd >}}
+
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/11_pyramide_ages_r_dbplyr.qmd >}}
 
 :::
 
@@ -708,6 +765,10 @@ ordre décroissant.
 ## `R` {.unnumbered .unlisted} 
 
 {{< include snippets/12_centenaires_r.qmd >}}
+
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/12_centenaires_r_dbplyr.qmd >}}
 
 :::
 
@@ -803,6 +864,10 @@ une base de données intégrant le code officiel géographique:
 ## `R` {.unnumbered .unlisted} 
 
 {{< include snippets/13_autres_sources_r.qmd >}}
+
+## `R (dbplyr)` {.unnumbered .unlisted} 
+
+{{< include snippets/13_autres_sources_r_dbplyr.qmd >}}
 
 :::
 

--- a/snippets/10_use_cast_r_dbplyr.qmd
+++ b/snippets/10_use_cast_r_dbplyr.qmd
@@ -1,0 +1,6 @@
+```r
+table_logement %>%
+  filter(COMMUNE == '31555', !IRANM %in% c('1', 'Z'), INPER != "Y") %>%
+  mutate(INPER = as.integer(INPER)) %>%
+  summarise(habitants_toulouse_demenagement = as.integer(sum(IPONDL * INPER)))
+```

--- a/snippets/11_pyramide_ages_r_dbplyr.qmd
+++ b/snippets/11_pyramide_ages_r_dbplyr.qmd
@@ -1,0 +1,18 @@
+```r
+library(labeling)
+library(ggplot2)
+
+pyramide_ages <- table_individu %>%
+  filter(DEPT %in% c('11', '31', '34')) %>%
+  group_by(AGED, departement = DEPT) %>%
+  summarise(individus = sum(IPONDI), .groups = "drop") %>%
+  arrange(departement, AGED) %>%
+  collect()
+
+ggplot(pyramide_ages, aes(x = AGED, y = individus)) +
+  geom_bar(aes(fill = departement), stat = "identity") +
+  geom_vline(xintercept = 18, color = "grey", linetype = "dashed") +
+  facet_wrap(~departement, scales = "free_y", nrow = 3) +
+  theme_minimal() +
+  labs(y = "Individus recensés", x = "Âge")
+```

--- a/snippets/12_centenaires_r_dbplyr.qmd
+++ b/snippets/12_centenaires_r_dbplyr.qmd
@@ -1,0 +1,8 @@
+```r
+table_individu %>%
+  filter(AGED >= 100) %>%
+  group_by(DEPT) %>%
+  summarise(individus_recenses = as.integer(sum(IPONDI)), .groups = "drop") %>%
+  arrange(desc(individus_recenses))
+```
+

--- a/snippets/13_autres_sources_r_dbplyr.qmd
+++ b/snippets/13_autres_sources_r_dbplyr.qmd
@@ -1,0 +1,17 @@
+```r
+url <- "https://www.insee.fr/fr/statistiques/fichier/6800675/v_commune_2023.csv"
+download.file(url, "cog.csv")
+```
+
+```r
+cog <- tbl(con, glue('read_csv_auto("{path_data}/cog.csv", header = true)'))
+```
+
+```r
+table_logement %>%
+  left_join(cog, by = c("COMMUNE" = "COM")) %>%
+  group_by(NCCENR) %>%
+  summarise(recenses = as.integer(sum(IPONDL)), .groups = "drop") %>%
+  arrange(recenses)
+```
+

--- a/snippets/1_create_db_r_dbplyr.qmd
+++ b/snippets/1_create_db_r_dbplyr.qmd
@@ -1,0 +1,69 @@
+```r
+library(duckdb)
+library(dplyr)
+library(stringr)
+library(glue)
+
+# Pour créer une base de données en mémoire
+con <- dbConnect(duckdb())
+
+path_data_sql <- DBI::SQL(path_data)
+
+renommage_documentation <-  DBI::SQL(paste(
+"SELECT",
+"COD_VAR AS nom_variable,",
+"LIB_VAR AS description_variable,",
+"TYPE_VAR AS type_variable,",
+"COD_MOD AS code_modalite,",
+"LIB_MOD AS description_modalite,",
+"LONG_VAR as longueur_variable"
+))
+
+
+dbExecute(
+  con,
+  glue_sql(  
+    'CREATE OR REPLACE VIEW table_individu AS ',
+    'SELECT * FROM read_parquet("{path_data_sql}/FD_INDCVI_2020.parquet")',
+    .con=con
+  )
+)
+
+table_individu <- tbl(con, "table_individu")
+# La requête pourrait aussi s'écrire directement dans l'appel à tbl :
+table_individu_direct <- tbl(con, glue('read_parquet("{path_data}/FD_INDCVI_2020.parquet")'))
+print(table_individu_direct)
+
+dbExecute(
+  con,
+  glue_sql(  
+    'CREATE OR REPLACE VIEW table_logement AS ',
+    'SELECT * FROM read_parquet("{path_data_sql}/FD_LOGEMT_2020.parquet")',
+    .con=con
+  )
+)
+table_logement <- tbl(con, "table_logement")
+
+dbExecute(
+  con,
+  glue_sql(
+  'CREATE OR REPLACE VIEW documentation_indiv AS ',
+  '{renommage_documentation} FROM ',
+  'read_csv_auto("{path_data_sql}/dictionnaire_variables_indcvi_2020.csv", header=true)',
+  .con=con
+  )
+)
+documentation_indiv <- tbl(con, "documentation_indiv")
+
+dbExecute(
+  con,
+  glue_sql(
+  'CREATE OR REPLACE VIEW documentation_logement AS ',
+  '{renommage_documentation} FROM ',
+  'read_csv_auto("{path_data_sql}/dictionnaire_variables_logemt_2020.csv", header=true)',
+  .con=con
+  )
+)
+documentation_logement <- tbl(con, "documentation_logement")
+
+```

--- a/snippets/2_select_schema_r_dbplyr.qmd
+++ b/snippets/2_select_schema_r_dbplyr.qmd
@@ -1,0 +1,6 @@
+```r
+
+print(head(documentation_indiv))
+
+print(head(documentation_logement))
+```

--- a/snippets/3_select_documentation_ojs.qmd
+++ b/snippets/3_select_documentation_ojs.qmd
@@ -1,5 +1,5 @@
 ```{{ojs}}
-query = "SELECT * FROM documentation_indiv WHERE CONTAINS(description_variable, 'Catégorie')"
+query = "SELECT * FROM documentation_logement WHERE CONTAINS(description_variable, 'Catégorie')"
 Inputs.table(
     db.query(query)
 )

--- a/snippets/3_select_documentation_python.qmd
+++ b/snippets/3_select_documentation_python.qmd
@@ -1,4 +1,4 @@
 ```python
-query = "SELECT * FROM documentation_indiv WHERE CONTAINS(description_variable, 'Catégorie')"
+query = "SELECT * FROM documentation_logement WHERE CONTAINS(description_variable, 'Catégorie')"
 duckdb.sql(query)
 ```

--- a/snippets/3_select_documentation_r.qmd
+++ b/snippets/3_select_documentation_r.qmd
@@ -1,4 +1,4 @@
 ```r
-query <- "SELECT * FROM documentation_indiv WHERE CONTAINS(description_variable, 'Catégorie')"
+query <- "SELECT * FROM documentation_logement WHERE CONTAINS(description_variable, 'Catégorie')"
 dbGetQuery(con, query)
 ```

--- a/snippets/3_select_documentation_r_dbplyr.qmd
+++ b/snippets/3_select_documentation_r_dbplyr.qmd
@@ -1,0 +1,4 @@
+```r
+documentation_logement %>%
+  filter(str_detect(description_variable, "catégorie"))
+```

--- a/snippets/4_selectz_r_dbplyr.qmd
+++ b/snippets/4_selectz_r_dbplyr.qmd
@@ -1,0 +1,5 @@
+```r
+documentation_indiv %>%
+  filter(str_detect(code_modalite, "Z"))
+```
+

--- a/snippets/5_limit_r_dbplyr.qmd
+++ b/snippets/5_limit_r_dbplyr.qmd
@@ -1,0 +1,4 @@
+```r
+table_logement %>% head(5)
+```
+

--- a/snippets/5_sample_r_dbplyr.qmd
+++ b/snippets/5_sample_r_dbplyr.qmd
@@ -1,0 +1,4 @@
+```r
+tbl(con, sql("SELECT * FROM table_logement USING SAMPLE 5"))
+```
+

--- a/snippets/6_sample_columns_r_dbplyr.qmd
+++ b/snippets/6_sample_columns_r_dbplyr.qmd
@@ -1,0 +1,6 @@
+```r
+table_individu %>%
+  select(poids = IPONDI, AGED, VOIT) %>%
+  head(10)
+```
+

--- a/snippets/7_use_regex_r_dbplyr.qmd
+++ b/snippets/7_use_regex_r_dbplyr.qmd
@@ -1,0 +1,6 @@
+```r
+table_individu %>%
+  select(poids = IPONDI, contains("AGE")) %>%
+  head(10)
+```
+

--- a/snippets/8_filter_dates_r_dbplyr.qmd
+++ b/snippets/8_filter_dates_r_dbplyr.qmd
@@ -1,0 +1,8 @@
+```r
+table_logement %>%
+  filter(COMMUNE == "06088") %>%
+  filter(AEMM > 2020)
+# Peut aussi s'écrire en une fois :
+# table_logement %>% filter(COMMUNE == "06088", AEMM > 2020)
+```
+

--- a/snippets/8_filter_dpts_r_dbplyr.qmd
+++ b/snippets/8_filter_dpts_r_dbplyr.qmd
@@ -1,0 +1,6 @@
+```r
+table_individu %>%
+  filter(DEPT %in% c("11", "31", "34")) %>%
+  head(10)
+```
+

--- a/snippets/8_filter_regions_r_dbplyr.qmd
+++ b/snippets/8_filter_regions_r_dbplyr.qmd
@@ -1,0 +1,6 @@
+```r
+liste_regions <- c("11", "31", "34")
+table_individu %>%
+  filter(DEPT %in% liste_regions)
+```
+

--- a/snippets/9_distinct_arrondissements_r_dbplyr.qmd
+++ b/snippets/9_distinct_arrondissements_r_dbplyr.qmd
@@ -1,0 +1,6 @@
+```r
+table_logement %>%
+  filter(str_detect(ARM, "ZZZZZ", negate = TRUE)) %>%
+  summarise(ARM = distinct(ARM)) %>%
+  arrange(ARM)
+```


### PR DESCRIPTION
All snippets converted to "native" dbplyr queries (except the `5_sample` that can't be converted natively at the moment, would require a `sample_n()` that isn't translated from dplyr to duckdb SQL right now).