### PR TITLE
Fix version html avec des lignes tronquées

### DIFF
--- a/note_pdf.qmd
+++ b/note_pdf.qmd
@@ -135,7 +135,7 @@ __Exemple `R`__
 schema_table_individu = duckdb.sql(
   "SELECT * FROM documentation_indiv"
   ).to_df()
-schema_table_individu.head(2)
+schema_table_individu[["nom_variable", "code_modalite", "description_modalite"]].head(2)
 ```
 
 
@@ -172,7 +172,13 @@ __Exemple `R`__
 
 ```{python}
 #| echo: false
-duckdb.sql("SELECT * FROM documentation_indiv WHERE CONTAINS(description_variable, 'Catégorie')")
+duckdb.sql(\
+"""
+  SELECT nom_variable, code_modalite, description_modalite 
+  FROM documentation_indiv 
+  WHERE CONTAINS(description_variable, 'Catégorie')
+"""
+)
 ```
 
 Cette approche peut permettre de récupérer les modalités d'une variable.
@@ -192,8 +198,11 @@ __Exemple `R`__
 
 ```{python}
 #| echo: false
-duckdb.sql(
-  "SELECT * FROM documentation_indiv WHERE CONTAINS(code_modalite, 'Z')"
+duckdb.sql(\
+"""
+  SELECT nom_variable, code_modalite, description_modalite 
+  FROM documentation_indiv WHERE CONTAINS(code_modalite, 'Z')
+"""
 )
 ```
 
@@ -220,7 +229,7 @@ __Exemple `R`__
 ```{python}
 #| echo: false
 #| output: true
-duckdb.sql("SELECT * FROM table_logement LIMIT 5")
+duckdb.sql("SELECT COMMUNE, ARM, IRIS, TYPC, TYPL FROM table_logement LIMIT 5")
 ```
 
 Pour un échantillon aléatoire, la commande à utiliser est `USING SAMPLE`.
@@ -241,7 +250,7 @@ __Exemple `R`__
 ```{python}
 #| echo: false
 # Echantillon aléatoire
-duckdb.sql("SELECT * FROM table_logement USING SAMPLE 5")
+duckdb.sql("SELECT COMMUNE, ARM, IRIS, TYPC, TYPL FROM table_logement USING SAMPLE 5")
 ```
 
 # Sélectionner des observations ou des variables
@@ -332,7 +341,7 @@ duckdb.sql("SELECT * FROM table_individu WHERE DEPT IN ('11', '31', '34')")
 #| output: false
 liste_regions = ["1", "2", "3"]
 liste_regions_sql = ", ".join([f"'{dep}'" for dep in liste_regions])
-duckdb.sql(f"SELECT * FROM table_individu WHERE DEPT IN ({liste_regions_sql})")
+duckdb.sql(f"SELECT CANTVILLE, NUMMI, ACHLR, DEPT FROM table_individu WHERE DEPT IN ({liste_regions_sql})")
 ```
 
 Les filtres sur les observations peuvent être faits à partir de critères
@@ -352,7 +361,7 @@ __Exemple `R`__
 
 ```{python}
 #| echo: false
-query = "SELECT * FROM table_logement WHERE COMMUNE = '06088' and AEMM > 2020"
+query = "SELECT COMMUNE, ARM, IRIS, AEEM FROM table_logement WHERE COMMUNE = '06088' and AEMM > 2020"
 duckdb.sql(query)
 ```
 

--- a/note_pdf.qmd
+++ b/note_pdf.qmd
@@ -135,8 +135,10 @@ __Exemple `R`__
 schema_table_individu = duckdb.sql(
   "SELECT * FROM documentation_indiv"
   ).to_df()
-schema_table_individu[["nom_variable", "code_modalite", "description_modalite"]].head(2)
+schema_table_individu[["code_modalite", "description_modalite", "nom_variable"]].head(2)
 ```
+
+\pagebreak
 
 
 ```{python}
@@ -169,6 +171,8 @@ __Exemple `Python`__
 __Exemple `R`__ 
 
 {{< include snippets/3_select_documentation_r.qmd >}}
+
+\pagebreak
 
 ```{python}
 #| echo: false
@@ -333,7 +337,7 @@ __Exemple `R`__
 
 ```{python}
 #| echo: false
-duckdb.sql("SELECT * FROM table_individu WHERE DEPT IN ('11', '31', '34')")
+duckdb.sql("SELECT CANTVILLE, NUMMI, ACHLR, DEPT FROM table_individu WHERE DEPT IN ('11', '31', '34')")
 ```
 
 ```{python}
@@ -341,7 +345,7 @@ duckdb.sql("SELECT * FROM table_individu WHERE DEPT IN ('11', '31', '34')")
 #| output: false
 liste_regions = ["1", "2", "3"]
 liste_regions_sql = ", ".join([f"'{dep}'" for dep in liste_regions])
-duckdb.sql(f"SELECT CANTVILLE, NUMMI, ACHLR, DEPT FROM table_individu WHERE DEPT IN ({liste_regions_sql})")
+duckdb.sql(f"SELECT * FROM table_individu WHERE DEPT IN ({liste_regions_sql})")
 ```
 
 Les filtres sur les observations peuvent être faits à partir de critères
@@ -361,7 +365,7 @@ __Exemple `R`__
 
 ```{python}
 #| echo: false
-query = "SELECT COMMUNE, ARM, IRIS, AEEM FROM table_logement WHERE COMMUNE = '06088' and AEMM > 2020"
+query = "SELECT COMMUNE, ARM, IRIS, AEMM FROM table_logement WHERE COMMUNE = '06088' and AEMM > 2020"
 duckdb.sql(query)
 ```
 

--- a/note_pdf.qmd
+++ b/note_pdf.qmd
@@ -3,7 +3,7 @@ title: Guide d'utilisation des données du recensement de la population au forma
 jupyter: python3
 embed-resources: true
 code-annotations: true
-date: 2023-10-18
+date: 2023-12-22
 bibliography: reference.bib
 format:
   pdf:
@@ -42,7 +42,7 @@ L'ensemble des codes utilisés pour produire cette note
 est disponible sur le
 dépôt [`Github` InseeFrLab/exemples-recensement-parquet](https://github.com/InseeFrLab/exemples-recensement-parquet)
 au format [`Quarto Markdown`](https://quarto.org/).
-Une version plus plus ergonomique et présentant des éléments
+Une version plus ergonomique et présentant des éléments
 complémentaires (`DuckDB` par le biais d'`Observable` et `Quarto`, visualisations réactives),
 est disponible sur le blog
 du [réseau des _data scientists_ de la statistique publique](https://ssphub.netlify.app/post/parquetrp/).
@@ -74,8 +74,8 @@ est plus intéressant pour le traitement de celles-ci comme expliqué
 par @dondon-lamarche-2023. Les données au format `Parquet` sont mises à disposition sur 
 le site `data.gouv` aux adresses suivantes:
 
-* [Fichier détail individuel](https://static.data.gouv.fr/resources/recensement-de-la-population-fichiers-detail-individus-localises-au-canton-ou-ville-2020-1)
-* [Fichier détail logement](https://static.data.gouv.fr/resources/recensement-de-la-population-fichiers-detail-individus-localises-au-canton-ou-ville-2020-1)
+* [Fichier détail individus](https://www.data.gouv.fr/fr/datasets/recensement-de-la-population-fichiers-detail-individus-localises-au-canton-ou-ville-2020-1/)
+* [Fichier détail logement](https://www.data.gouv.fr/fr/datasets/recensement-de-la-population-fichiers-detail-logements-ordinaires-en-2020-1/)
 
 
 Ces fichiers peuvent être téléchargés par la biais de `Python`

--- a/snippets/0_download_data_python.qmd
+++ b/snippets/0_download_data_python.qmd
@@ -8,10 +8,25 @@ def download_file(url, filename):
         with open(filename, 'wb') as f:
             f.write(response.content)
 
-url_table_logement = "https://static.data.gouv.fr/resources/recensement-de-la-population-fichiers-detail-logements-ordinaires-en-2020-1/20231023-123618/fd-logemt-2020.parquet"
-url_table_individu = "https://static.data.gouv.fr/resources/recensement-de-la-population-fichiers-detail-individus-localises-au-canton-ou-ville-2020-1/20231023-122841/fd-indcvi-2020.parquet"
-url_doc_logement = "https://www.data.gouv.fr/fr/datasets/r/c274705f-98db-4d9b-9674-578e04f03198"
-url_doc_individu = "https://www.data.gouv.fr/fr/datasets/r/1c6c6ab2-b766-41a4-90f0-043173d5e9d1"
+url_table_logement = (
+    "https://static.data.gouv.fr/resources/"
+    "recensement-de-la-population-fichiers-detail-logements-ordinaires-en-2020-1/"
+    "20231023-123618/fd-logemt-2020.parquet"
+)
+url_table_individu = (
+    "https://static.data.gouv.fr/resources/"
+    "recensement-de-la-population-fichiers-detail-individus"
+    "-localises-au-canton-ou-ville-2020-1"
+    "/20231023-122841/fd-indcvi-2020.parquet"
+)
+url_doc_logement = (
+    "https://www.data.gouv.fr/fr/datasets/r/"
+    "c274705f-98db-4d9b-9674-578e04f03198"
+)
+url_doc_individu = (
+    "https://www.data.gouv.fr/fr/datasets/r/"
+    "1c6c6ab2-b766-41a4-90f0-043173d5e9d1"
+)
 
 download_file(url_table_logement, "FD_LOGEMT_2020.parquet")
 download_file(url_table_individu, "FD_INDCVI_2020.parquet")

--- a/snippets/0_download_data_r.qmd
+++ b/snippets/0_download_data_r.qmd
@@ -1,8 +1,14 @@
 ```r
-url_table_logement <- "https://static.data.gouv.fr/resources/recensement-de-la-population-fichiers-detail-logements-ordinaires-en-2020-1/20231023-123618/fd-logemt-2020.parquet"
-url_table_individu <- "https://static.data.gouv.fr/resources/recensement-de-la-population-fichiers-detail-individus-localises-au-canton-ou-ville-2020-1/20231023-122841/fd-indcvi-2020.parquet"
-url_doc_logement <- "https://www.data.gouv.fr/fr/datasets/r/c274705f-98db-4d9b-9674-578e04f03198"
-url_doc_individu <- "https://www.data.gouv.fr/fr/datasets/r/1c6c6ab2-b766-41a4-90f0-043173d5e9d1"
+url_table_logement <- paste("https://static.data.gouv.fr/resources/",
+                    "recensement-de-la-population-fichiers-detail-logements-ordinaires-en-2020-1/",
+                    "20231023-123618/fd-logemt-2020.parquet"
+url_table_individu <- paste("https://static.data.gouv.fr/resources",
+                    "recensement-de-la-population-fichiers-detail-individus-",
+                    "localises-au-canton-ou-ville-2020-1/20231023-122841/fd-indcvi-2020.parquet"
+url_doc_logement <- paste("https://www.data.gouv.fr/fr/datasets/r/",
+                    "c274705f-98db-4d9b-9674-578e04f03198"
+url_doc_individu <- paste("https://www.data.gouv.fr/fr/datasets/r/",
+                    "1c6c6ab2-b766-41a4-90f0-043173d5e9d1"
 
 options(timeout = max(300, getOption("timeout")))
 

--- a/snippets/0_download_data_r.qmd
+++ b/snippets/0_download_data_r.qmd
@@ -1,14 +1,14 @@
 ```r
 url_table_logement <- paste("https://static.data.gouv.fr/resources/",
-                    "recensement-de-la-population-fichiers-detail-logements-ordinaires-en-2020-1/",
-                    "20231023-123618/fd-logemt-2020.parquet"
+    "recensement-de-la-population-fichiers-detail-logements-ordinaires-en-2020-1/",
+    "20231023-123618/fd-logemt-2020.parquet"
 url_table_individu <- paste("https://static.data.gouv.fr/resources",
-                    "recensement-de-la-population-fichiers-detail-individus-",
-                    "localises-au-canton-ou-ville-2020-1/20231023-122841/fd-indcvi-2020.parquet"
+    "recensement-de-la-population-fichiers-detail-individus-",
+    "localises-au-canton-ou-ville-2020-1/20231023-122841/fd-indcvi-2020.parquet"
 url_doc_logement <- paste("https://www.data.gouv.fr/fr/datasets/r/",
-                    "c274705f-98db-4d9b-9674-578e04f03198"
+    "c274705f-98db-4d9b-9674-578e04f03198"
 url_doc_individu <- paste("https://www.data.gouv.fr/fr/datasets/r/",
-                    "1c6c6ab2-b766-41a4-90f0-043173d5e9d1"
+    "1c6c6ab2-b766-41a4-90f0-043173d5e9d1"
 
 options(timeout = max(300, getOption("timeout")))
 

--- a/snippets/3_select_documentation_python.qmd
+++ b/snippets/3_select_documentation_python.qmd
@@ -1,4 +1,8 @@
 ```python
-query = "SELECT * FROM documentation_logement WHERE CONTAINS(description_variable, 'Catégorie')"
+query = \
+"""
+    SELECT * FROM documentation_logement 
+    WHERE CONTAINS(description_variable, 'Catégorie')
+"""
 duckdb.sql(query)
 ```

--- a/snippets/3_select_documentation_r.qmd
+++ b/snippets/3_select_documentation_r.qmd
@@ -1,4 +1,6 @@
 ```r
-query <- "SELECT * FROM documentation_logement WHERE CONTAINS(description_variable, 'Catégorie')"
+query <- paste(
+    "SELECT * FROM documentation_logement ",
+    "WHERE CONTAINS(description_variable, 'Catégorie')"
 dbGetQuery(con, query)
 ```


### PR DESCRIPTION
- Remise en forme de certains éléments de la note PDF pour éviter que certains lignes soient tronquées. J'ai essayé de toucher le moins possible aux snippets (en commun avec la version web?)
- Reste un tableau tronqué mais on peut difficilement afficher moins de variables.
- Un peu de relecture au passage